### PR TITLE
The hidden textarea width should be the same as the original textarea

### DIFF
--- a/jquery.simpleautogrow.js
+++ b/jquery.simpleautogrow.js
@@ -23,7 +23,7 @@
 				this.timer = window.setInterval(function() {self.checkExpand(); }, 200); })
 			.bind('blur', function() { clearInterval(this.timer); });
 		this.border = $e.outerHeight() - $e.innerHeight();
-		this.clone = $e.clone().css({position: 'absolute', visibility: 'hidden'}).attr('name', '')
+		this.clone = $e.clone().css({position: 'absolute', visibility: 'hidden', width: ($e.innerWidth()+'px')}).attr('name', '')
 		$e.height(e.scrollHeight + this.border)
 			.after(this.clone);
 		this.checkExpand(); };


### PR DESCRIPTION
Hi,

If the width of the hidden textarea doesn't match the width of the original one, it won't autogrow correctly. You will find yourself typing text you cannot see.

I just added the width attribute for the cloned texarea.

Thanks,
Aukan 
